### PR TITLE
Fix V3066

### DIFF
--- a/SparrowSharp.Core/Filters/FragmentFilter.cs
+++ b/SparrowSharp.Core/Filters/FragmentFilter.cs
@@ -355,7 +355,7 @@ namespace SparrowSharp.Filters
             SparrowSharpApp.Context.ScissorBox = null; // we want the entire texture cleared
             support.Clear();
             support.BlendMode = BlendMode.NORMAL;
-            support.SetupOrthographicProjection(boundsPOT.Left, boundsPOT.Right, boundsPOT.Bottom, boundsPOT.Top);
+            support.SetupOrthographicProjection(boundsPOT.Left, boundsPOT.Right, boundsPOT.Top, boundsPOT.Bottom);
             obj.Render(support);
             support.FinishQuadBatch();
 


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

* Possible incorrect order of arguments passed to 'SetupOrthographicProjection' method: 'boundsPOT.Bottom' and 'boundsPOT.Top'. SparrowSharp.Core.Desktop FragmentFilter.cs 358